### PR TITLE
[AUTH48] Fix CBOR map labels with diagnostic notation

### DIFF
--- a/auth48/rfc9202.xml
+++ b/auth48/rfc9202.xml
@@ -333,14 +333,14 @@ server is depicted in <xref target="rpk-authorization-message-example" format="d
    Content-Format: application/ace+cbor
    Payload:
    {
-     grant_type : client_credentials,
-     audience   : "tempSensor4711",
-     req_cnf    : {
-       COSE_Key : {
-         kty : EC2,
-         crv : P-256,
-         x   : h'e866c35f4c3c81bb96a1...',
-         y   : h'2e25556be097c8778a20...'
+     / grant_type / 33 : / client_credentials / 2,
+     / audience / 5    : "tempSensor4711",
+     / req_cnf / 4     : {
+       / COSE_Key / 1 : {
+         / kty / 1  : / EC2 / 2,
+         / crv / -1 : / P-256 / 1,
+         / x / -2   : h'e866c35f4c3c81bb96a1...',
+         / y / -3   : h'2e25556be097c8778a20...'
        }
      }
    }
@@ -397,16 +397,16 @@ means of the <tt>cnf</tt> claim.</t>
    Max-Age: 3560
    Payload:
    {
-     access_token : b64'SlAV32hkKG...
+     / access_token / 1 : b64'SlAV32hkKG...
       (remainder of CWT omitted for brevity;
       CWT contains the client's RPK in the cnf claim)',
-     expires_in : 3600,
-     rs_cnf     : {
-       COSE_Key : {
-         kty : EC2,
-         crv : P-256,
-         x   : h'd7cc072de2205bdc1537...',
-         y   : h'f95e1d4b851a2cc80fff...'
+     / expires_in / 2 : 3600,
+     / rs_cnf / 41    : {
+       / COSE_Key / 1 : {
+         / kty / 1  : / EC2 / 2,
+         / crv / -1 : / P-256 / 1,
+         / x / -2   : h'd7cc072de2205bdc1537...',
+         / y / -3   : h'f95e1d4b851a2cc80fff...'
        }
      }
    }
@@ -563,7 +563,7 @@ proof-of-possession key is illustrated in <xref target="at-request" format="defa
    Content-Format: application/ace+cbor
    Payload:
    {
-     audience    : "smokeSensor1807",
+     / audience / 5    : "smokeSensor1807",
    }
 ]]></sourcecode>
           </figure>
@@ -583,16 +583,16 @@ structure as specified in <xref target="RFC9200" format="default"/>.</t>
    Max-Age: 85800
    Payload:
    {
-      access_token : h'd08343a10...
-      (remainder of CWT omitted for brevity)
-      token_type  : PoP,
-      expires_in  : 86400,
-      ace_profile : coap_dtls,
-      cnf         : {
-        COSE_Key  : {
-          kty : symmetric,
-          kid : h'3d027833fc6267ce',
-          k   : h'73657373696f6e6b6579'
+      / access_token / 1 : h'd08343a10...
+        (remainder of CWT omitted for brevity)
+      / token_type / 34  : / PoP / 2,
+      / expires_in / 2   : 86400,
+      / ace_profile / 38 : / coap_dtls / 1,
+      / cnf / 8         : {
+        / COSE_Key / 1  : {
+          / kty / 1 : / symmetric / 4,
+          / kid / 2 : h'3d027833fc6267ce',
+          / k /  -1 : h'73657373696f6e6b6579'
         }
       }
    }
@@ -611,10 +611,10 @@ token.</t>
           <figure anchor="kdf-cnf">
             <name>Access Token without Keying Material</name>
             <sourcecode type="cbor-diag"><![CDATA[
-cnf : {
-  COSE_Key : {
-    kty : symmetric,
-    kid : h'3d027833fc6267ce'
+/ cnf / 8 : {
+  / COSE_Key / 1 : {
+    / kty / 1 : / symmetric / 4,
+    / kid / 2 : h'3d027833fc6267ce'
   }
 }
 ]]></sourcecode>
@@ -631,7 +631,7 @@ request parameters.</t>
     Content-Format: application/ace+cbor
     Payload:
     {
-      error : invalid_request
+      / error / 30 : / invalid_request / 1
     }
 ]]></sourcecode>
           </figure>
@@ -737,10 +737,10 @@ communicate.</t>
           <figure anchor="psk_identity-cnf">
             <name>Access Token Containing a Single <tt>kid</tt> Parameter</name>
             <sourcecode type="cbor-diag"><![CDATA[
-{ cnf : {
-   COSE_Key : {
-      kty: symmetric,
-      kid : h'3d027833fc6267ce'
+{ / cnf / 8 : {
+   / COSE_Key / 1 : {
+      / kty / 1 : / symmetric / 4,
+      / kid / 2 : h'3d027833fc6267ce'
     }
   }
 }

--- a/auth48/rfc9202.xml
+++ b/auth48/rfc9202.xml
@@ -563,7 +563,7 @@ proof-of-possession key is illustrated in <xref target="at-request" format="defa
    Content-Format: application/ace+cbor
    Payload:
    {
-     / audience / 5    : "smokeSensor1807",
+     / audience / 5    : "smokeSensor1807"
    }
 ]]></sourcecode>
           </figure>

--- a/auth48/rfc9202.xml
+++ b/auth48/rfc9202.xml
@@ -334,13 +334,13 @@ server is depicted in <xref target="rpk-authorization-message-example" format="d
    Payload:
    {
      / grant_type / 33 : / client_credentials / 2,
-     / audience / 5    : "tempSensor4711",
-     / req_cnf / 4     : {
+     / audience /    5 : "tempSensor4711",
+     / req_cnf /     4 : {
        / COSE_Key / 1 : {
-         / kty / 1  : / EC2 / 2,
+         / kty /  1 : / EC2 /   2,
          / crv / -1 : / P-256 / 1,
-         / x / -2   : h'e866c35f4c3c81bb96a1...',
-         / y / -3   : h'2e25556be097c8778a20...'
+         / x /   -2 : h'e866c35f4c3c81bb96a1...',
+         / y /   -3 : h'2e25556be097c8778a20...'
        }
      }
    }
@@ -400,13 +400,13 @@ means of the <tt>cnf</tt> claim.</t>
      / access_token / 1 : b64'SlAV32hkKG...
       (remainder of CWT omitted for brevity;
       CWT contains the client's RPK in the cnf claim)',
-     / expires_in / 2 : 3600,
-     / rs_cnf / 41    : {
-       / COSE_Key / 1 : {
-         / kty / 1  : / EC2 / 2,
+     / expires_in /  2 : 3600,
+     / rs_cnf /     41 : {
+       / COSE_Key /  1 : {
+         / kty /  1 : / EC2 /   2,
          / crv / -1 : / P-256 / 1,
-         / x / -2   : h'd7cc072de2205bdc1537...',
-         / y / -3   : h'f95e1d4b851a2cc80fff...'
+         / x /   -2 : h'd7cc072de2205bdc1537...',
+         / y /   -3 : h'f95e1d4b851a2cc80fff...'
        }
      }
    }
@@ -563,7 +563,7 @@ proof-of-possession key is illustrated in <xref target="at-request" format="defa
    Content-Format: application/ace+cbor
    Payload:
    {
-     / audience / 5    : "smokeSensor1807"
+     / audience / 5 : "smokeSensor1807"
    }
 ]]></sourcecode>
           </figure>
@@ -583,13 +583,13 @@ structure as specified in <xref target="RFC9200" format="default"/>.</t>
    Max-Age: 85800
    Payload:
    {
-      / access_token / 1 : h'd08343a10...
+      / access_token /  1 : h'd08343a10...
         (remainder of CWT omitted for brevity)
-      / token_type / 34  : / PoP / 2,
-      / expires_in / 2   : 86400,
-      / ace_profile / 38 : / coap_dtls / 1,
-      / cnf / 8         : {
-        / COSE_Key / 1  : {
+      / token_type /   34 : / PoP / 2,
+      / expires_in /    2 : 86400,
+      / ace_profile /  38 : / coap_dtls / 1,
+      / cnf /           8 : {
+        / COSE_Key / 1 : {
           / kty / 1 : / symmetric / 4,
           / kid / 2 : h'3d027833fc6267ce',
           / k /  -1 : h'73657373696f6e6b6579'
@@ -677,8 +677,8 @@ key identifier, the key derivation key, and other data:</t>
           <sourcecode type="cddl"><![CDATA[
       info = [
         type : tstr,
-        L : uint,
-        access_token: bytes
+        L    : uint,
+        access_token : bytes
       ]
 ]]></sourcecode>
           <t>where:</t>


### PR DESCRIPTION
Replace syntactically incorrect CBOR mapkeys

```
{ 
      token_type  : PoP,
      expires_in  : 86400,
      ace_profile : coap_dtls,
...
}
```

with their numeric values in diagnostic notation:

```
{
      / token_type / 34  : / PoP / 2,
      / expires_in / 2  : 86400,
      / ace_profile / 38 : / coap_dtls / 1,
...
}
```